### PR TITLE
Refactor VideoPlayer component to improve rewind and forward function

### DIFF
--- a/packages/media-console/src/VideoPlayer.tsx
+++ b/packages/media-console/src/VideoPlayer.tsx
@@ -395,6 +395,38 @@ const AnimatedVideoPlayer = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  
+  let accumulatedRewindTime = 0; 
+  const rewind = () => {
+    if (currentTime === 0) return;
+    if(timeoutId) clearTimeout(timeoutId);
+    accumulatedRewindTime += rewindTime
+
+    timeoutId = setTimeout(() => {
+        videoRef?.current?.seek(currentTime - accumulatedRewindTime);
+
+        accumulatedRewindTime = 0;
+
+        timeoutId = null;
+    }, 700);
+  }
+
+  let accumulatedForwardTime = 0;
+  const forward = () => {
+    if (currentTime === 0) return;
+    if(timeoutId) clearTimeout(timeoutId);
+    accumulatedForwardTime += rewindTime
+    timeoutId = setTimeout(() => {
+        videoRef?.current?.seek(currentTime + accumulatedForwardTime);
+
+        accumulatedForwardTime = 0;
+
+        timeoutId = null;
+    }, 700);
+  }
+
   return (
     <PlatformSupport
       showControls={showControls}
@@ -439,12 +471,8 @@ const AnimatedVideoPlayer = (
               togglePlayPause={togglePlayPause}
               resetControlTimeout={resetControlTimeout}
               showControls={showControls}
-              onPressRewind={() =>
-                videoRef?.current?.seek(currentTime - rewindTime)
-              }
-              onPressForward={() =>
-                videoRef?.current?.seek(currentTime + rewindTime)
-              }
+              onPressRewind={rewind}
+              onPressForward={forward}
             />
             <BottomControls
               animations={animations}


### PR DESCRIPTION
Issue: Tapping on the forward or rewind button sets the currentTime to 0 until buffering So quickly tapping on the buttons more than once starts the video from start.

I throttled forward and rewind function to use accumulated time.
if this is not the correct way please fix this issue.